### PR TITLE
Add language choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Type: `String`
 
 The path to the translation file to be upload to your OneSky project.
 
-#### options.language
+#### options.locale
 Type: `String` Default value: Your project main language
 
 The language (and region if specified) of your file. For example, you will use `en-GB` if you want to upload a file in english especially for Great Britain.
@@ -79,7 +79,7 @@ grunt.initConfig({
         },
         import: {
             options: {
-                language: 'en-GB',
+                locale: 'en-GB',
                 file: 'media.json',
                 fileFormat: 'HIERARCHICAL_JSON'
             }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Type: `String`
 
 The path to the translation file to be upload to your OneSky project.
 
+#### options.language
+Type: `String` Default value: Your project main language
+
+The language (and region if specified) of your file. For example, you will use `en-GB` if you want to upload a file in english especially for Great Britain.
+
 #### options.fileFormat
 Type: `String`
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ grunt.initConfig({
         },
         import: {
             options: {
+                language: 'en-GB',
                 file: 'media.json',
                 fileFormat: 'HIERARCHICAL_JSON'
             }

--- a/tasks/onesky_import.js
+++ b/tasks/onesky_import.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
         var options = this.options({
             authFile: 'onesky.json',
             projectId: '',
-            language:'',
+            language: '',
             file: '',
             fileFormat: 'HIERARCHICAL_JSON',
             isKeepingAllStrings: true
@@ -71,12 +71,13 @@ module.exports = function (grunt) {
             function onUploadSuccess(data) {
                 var importId;
                 var locale;
+                var region;
 
                 if (_.has(data, 'data.import.id')) { importId = data.data.import.id; }
                 if (_.has(data, 'data.language.locale')) { locale = data.data.language.locale; }
                 if (_.has(data, 'data.language.region')) { region = data.data.language.region; }
-
-                grunt.log.ok('File: "' + options.file + '" uploaded. Import ID: ' + importId + '. Locale: ' + locale + ' Region: ' + region);
+                grunt.log.ok('File: "' + options.file +
+                    '" uploaded. Import ID: ' + importId + '. Locale: ' + locale + ' Region: ' + region);
             }
 
             function onUploadError(data) {

--- a/tasks/onesky_import.js
+++ b/tasks/onesky_import.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
         var options = this.options({
             authFile: 'onesky.json',
             projectId: '',
+            language:'',
             file: '',
             fileFormat: 'HIERARCHICAL_JSON',
             isKeepingAllStrings: true
@@ -40,6 +41,7 @@ module.exports = function (grunt) {
             form.append('dev_hash', api.devHash);
             form.append('file', fs.createReadStream(options.file));
             form.append('file_format', options.fileFormat);
+            form.append('locale', options.language);
 
             if (_.isBoolean(options.isKeepingAllStrings)) {
                 form.append('is_keeping_all_strings', options.isKeepingAllStrings.toString());
@@ -72,8 +74,9 @@ module.exports = function (grunt) {
 
                 if (_.has(data, 'data.import.id')) { importId = data.data.import.id; }
                 if (_.has(data, 'data.language.locale')) { locale = data.data.language.locale; }
+                if (_.has(data, 'data.language.region')) { region = data.data.language.region; }
 
-                grunt.log.ok('File: "' + options.file + '" uploaded. Import ID: ' + importId + '. Locale: ' + locale);
+                grunt.log.ok('File: "' + options.file + '" uploaded. Import ID: ' + importId + '. Locale: ' + locale + ' Region: ' + region);
             }
 
             function onUploadError(data) {

--- a/tasks/onesky_import.js
+++ b/tasks/onesky_import.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
         var options = this.options({
             authFile: 'onesky.json',
             projectId: '',
-            language: '',
+            locale: '',
             file: '',
             fileFormat: 'HIERARCHICAL_JSON',
             isKeepingAllStrings: true
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
             form.append('dev_hash', api.devHash);
             form.append('file', fs.createReadStream(options.file));
             form.append('file_format', options.fileFormat);
-            form.append('locale', options.language);
+            form.append('locale', options.locale);
 
             if (_.isBoolean(options.isKeepingAllStrings)) {
                 form.append('is_keeping_all_strings', options.isKeepingAllStrings.toString());


### PR DESCRIPTION
Hello, the purpose of this pull request is to enable the developer to choose the language of his files. For example in case there is a couple language in a web application, it enables the developer to upload the translation on onesky. I just added the parameter `language` in `import.options` in the file `tasks/onesky_import.js` so that it's easy to modify it.
Best regards,
Vincent